### PR TITLE
By moving the function and options field inside the export function, …

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,33 +8,32 @@ var PluginError = gutil.PluginError;
 
 var PLUGIN_NAME = 'gulp-wkhtmltopdf';
 
-var options = {};
-
-function transform(file, enc, cb) {
-    if (file.isNull()) {
-        cb(null, file);
-        return;
-    }
-
-    if (file.isStream()) {
-        this.emit('error', new PluginError(PLUGIN_NAME, 'Streaming not supported'));
-        cb();
-        return;
-    }
-
-    file.path = gutil.replaceExtension(file.path, '.pdf');
-
-    var pdfStream = wkhtmltopdf(file.contents.toString(enc), options);
-    var outStream = through();
-    pdfStream.on('error', this.emit.bind(this, 'error'));
-    pdfStream.pipe(outStream);
-    file.contents = outStream;
-
-    this.push(file);
-    cb();
-}
-
 module.exports = function (opts) {
-    options = opts || {};
+    var options = opts || {};
+
+    function transform(file, enc, cb) {
+        if (file.isNull()) {
+            cb(null, file);
+            return;
+        }
+
+        if (file.isStream()) {
+            this.emit('error', new PluginError(PLUGIN_NAME, 'Streaming not supported'));
+            cb();
+            return;
+        }
+
+        file.path = gutil.replaceExtension(file.path, '.pdf');
+
+        var pdfStream = wkhtmltopdf(file.contents.toString(enc), options);
+        var outStream = through();
+        pdfStream.on('error', this.emit.bind(this, 'error'));
+        pdfStream.pipe(outStream);
+        file.contents = outStream;
+
+        this.push(file);
+        cb();
+    }
+
     return through.obj(transform);
 };


### PR DESCRIPTION
…we make sure the plugin can be used in parallel because the scope is isolated (i.e. it works with asynchronous calls to the plugin)
